### PR TITLE
Compile fix for unity 2018

### DIFF
--- a/Merlin/Scripts/MSDFAtlasGenerator.cs
+++ b/Merlin/Scripts/MSDFAtlasGenerator.cs
@@ -161,7 +161,7 @@ public class MSDFAtlasGenerator : EditorWindow
         if (UseTextureCompression)
         {
             EditorUtility.DisplayProgressBar("Generating MSDF Atlas...", "Compressing Atlas...", 1f);
-            EditorUtility.CompressTexture(newAtlas, TextureFormat.BC7, TextureCompressionQuality.Best);
+            EditorUtility.CompressTexture(newAtlas, TextureFormat.BC7, UnityEditor.TextureCompressionQuality.Best);
         }
 
         EditorUtility.ClearProgressBar();


### PR DESCRIPTION
Minor fix - resolves the following error in Unity 2018:
`Assets\Merlin\Scripts\MSDFAtlasGenerator.cs(164,72): error CS0104: 'TextureCompressionQuality' is an ambiguous reference between 'UnityEditor.TextureCompressionQuality' and 'UnityEngine.TextureCompressionQuality'`